### PR TITLE
Movement Improvements

### DIFF
--- a/lib/CommandParser.js
+++ b/lib/CommandParser.js
@@ -53,7 +53,7 @@ class CommandParser {
     }
 
     // see if they matched a direction for a movement command
-    const roomDirection = this.checkMovement(command);
+    const roomDirection = this.checkMovement(player, command);
     
     if (roomDirection) {
       const roomExit = this.canGo(player, roomDirection);
@@ -112,10 +112,11 @@ class CommandParser {
 
   /**
    * Check command for partial match on primary directions, or exact match on secondary name or abbreviation
+   * @param {Player} player
    * @param {string} command
    * @return {?string}
    */
-  static checkMovement(command)
+  static checkMovement(player, command)
   {
     const primaryDirections = ['north', 'south', 'east', 'west', 'up', 'down'];
 
@@ -138,7 +139,9 @@ class CommandParser {
       }
     }
 
-    return null;
+    const otherExit = player.room.getExits().find(roomExit => roomExit.direction === command);
+
+    return otherExit.direction || null;
   }
 
   /**
@@ -153,7 +156,7 @@ class CommandParser {
       return false;
     }
 
-    return player.room.findExit(direction);
+    return player.room.getExits().find(roomExit => roomExit.direction === direction) || false;
   }
 }
 exports.CommandParser = CommandParser;

--- a/lib/CommandParser.js
+++ b/lib/CommandParser.js
@@ -113,7 +113,7 @@ class CommandParser {
   /**
    * Check command for partial match on primary directions, or exact match on secondary name or abbreviation
    * @param {string} command
-   *  @return {?string}
+   * @return {?string}
    */
   static checkMovement(command)
   {

--- a/lib/CommandParser.js
+++ b/lib/CommandParser.js
@@ -141,7 +141,7 @@ class CommandParser {
 
     const otherExit = player.room.getExits().find(roomExit => roomExit.direction === command);
 
-    return otherExit.direction || null;
+    return otherExit ? otherExit.direction : null;
   }
 
   /**

--- a/lib/CommandParser.js
+++ b/lib/CommandParser.js
@@ -52,10 +52,12 @@ class CommandParser {
       };
     }
 
-    const roomExit = this.canGo(player, command);
-
-    // See if the command is an exit and the player can go that way
-    if (roomExit) {
+    // see if they matched a direction for a movement command
+    const roomDirection = this.checkMovement(command);
+    
+    if (roomDirection) {
+      const roomExit = this.canGo(player, roomDirection);
+    
       return {
         type: CommandType.MOVEMENT,
         args,
@@ -109,8 +111,39 @@ class CommandParser {
   }
 
   /**
+   * Check command for partial match on primary directions, or exact match on secondary name or abbreviation
+   * @param {string} command
+   *  @return {?string}
+   */
+  static checkMovement(command)
+  {
+    const primaryDirections = ['north', 'south', 'east', 'west', 'up', 'down'];
+
+    for (const direction of primaryDirections) {
+      if (direction.indexOf(command) === 0) {
+        return direction;
+      }
+    }
+
+    const secondaryDirections = [
+      { abbr: 'ne', name: 'northeast' },
+      { abbr: 'nw', name: 'northwest' },
+      { abbr: 'se', name: 'southeast' },
+      { abbr: 'sw', name: 'southwest' }
+    ];
+
+    for (const direction of secondaryDirections) {
+      if (direction.abbr === command || direction.name === command) {
+        return direction.name;
+      }
+    }
+
+    return null;
+  }
+
+  /**
    * Determine if a player can leave the current room to a given direction
-   * @param {Player} direction
+   * @param {Player} player
    * @param {string} direction
    * @return {boolean}
    */
@@ -119,16 +152,6 @@ class CommandParser {
     if (!player.room) {
       return false;
     }
-
-    // n/s/e/w/etc. get handled by indexOf. ne/se/etc have to be special-cased
-    const directions = {
-      'ne': 'northeast',
-      'se': 'southeast',
-      'nw': 'northwest',
-      'sw': 'southwest',
-    };
-
-    direction = directions[direction] || direction;
 
     return player.room.findExit(direction);
   }

--- a/lib/CommandParser.js
+++ b/lib/CommandParser.js
@@ -133,7 +133,7 @@ class CommandParser {
     ];
 
     for (const direction of secondaryDirections) {
-      if (direction.abbr === command || direction.name === command) {
+      if (direction.abbr === command || direction.name.indexOf(command) === 0) {
         return direction.name;
       }
     }


### PR DESCRIPTION
Previously, movement commands parsed were based on available rooms.

Now they are based on coded directions regardless of what is available in the room.

Combine this with a PR I'm working on for bundle-example-player-events that adds the following to the move listener, and it works as intended (other PR: https://github.com/RanvierMUD/bundle-example-player-events/pull/2)